### PR TITLE
HRHS-389: Sync with Upstream, Use deprecated-react-native-listview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+
+
+## [0.2.9] - 2019-07-28
 ### Added
 - Adapting for web, by neutralizing LayoutAnimation (#145)
+
+### Changed
+- Use ListView from deprecated-react-native-listview (#166)
 
 ## [0.2.8] - 2018-02-01
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,28 +21,32 @@ See [Sortable](Sortable).
 
 ## Props
 
-SortableListView passes through all the standard ListView properties to ListView, except for dataSource. The renderRow method must render a component that forwards onLongPress and onPressOut methods to a Touchable* child component.  Calling the onLongPress method will enable the drag and drop on the row and onPressOut will cancel it. You can also apply the default behaviour by spreading the sortHandlers prop (e.g. `<TouchableHightlight {...this.props.sortHandlers} >..`)
+SortableListView passes through all the [standard ListView properties](https://facebook.github.io/react-native/docs/listview#props) to ListView, except for dataSource. The renderRow method must render a component that forwards onLongPress and onPressOut methods to a Touchable* child component.  Calling the onLongPress method will enable the drag and drop on the row and onPressOut will cancel it. You can also apply the default behaviour by spreading the sortHandlers prop (e.g. `<TouchableHightlight {...this.props.sortHandlers} >..`)
 
- - **`onRowMoved`** _(Function)_ - should return a function that is passed a single object when a row is dropped. The object contains three properties `from`, `to`, and `row`. `from` and `to` are the order indexes being requested to move. `row` is all the info available about the row being dropped.
- - **`data`** _(Object)_ - Takes an object.
- - **`rowHasChanged`** _(Function)_ - Takes an function that is called to compare row data. It is passed the new row data and a shallow copy of the previous row data. **This is necessary to define if row data is not immutible for row changes to correctly propagate, if your row data is immutable DO NOT DEFINE, see #28 for reasons why**.
- - **`order`** _(Array)_  (optional) - Expects an array of keys to determine the current order of rows.
- - **`sortRowStyle`** _(Object)_ (optional) - Expects a `style` object, which is to be applied on the rows when they're being dragged.
- - **`disableSorting`** _(boolean) (optional) - When set to true, all sorting will be disabled, which will effectively make the SortableListView act like a normal ListView.
- - **`onMoveStart`** _(Function)_ (Optional) - Register a handler to be called when drag start.
- - **`onMoveEnd`** _(Function)_ (Optional) - Register a handler to be called when move is completed.
- - **`onRowActive`** _(Function)_ (Optional) - Register a handler to be called when row is activated, return a object contains three properties `rowData`, `touch` and `layout`. `rowData` is the data info of activated row, `layout` is the layout info of the activated row, `touch` is the `nativeEvent` of long press
- - **`onMoveCancel`** _(Function)_ (Optional) - Register a handler to be called when move is canceled, that is the row is activated on long press and then released without any move.
- - **`activeOpacity`** _(Number)_ (Optional) - Sets opacity of an active element. Default value: `0.2`.
- - **`limitScrolling`** _(boolean) (optional) - When set to true, scrolling will be disabled when a row is active (sorting). Default is `false`.
- - **`moveOnPressIn`** _(boolean) (optional) - When set to true, longPress delay is eliminated. Default is `false`.
- - **`ListViewComponent`** _(Function) (optional) - A custom ListView component to be used instead of React-Native's ListView.
- - **`disableAnimatedScrolling`** _(boolean) (optional) - When set to true, scrolling will no longer animate. Default is `false`. **Strongly recommend set it to `true`.**, see #97 for more context.
+Property |Type |Description
+:--- |:--- |:---
+**`onRowMoved`** | Function | should return a function that is passed a single object when a row is dropped. The object contains three properties `from`, `to`, and `row`. `from` and `to` are the order indexes being requested to move. `row` is all the info available about the row being dropped.
+**`data`** | Object | Takes an object.
+**`rowHasChanged`** | Function | Takes an function that is called to compare row data. It is passed the new row data and a shallow copy of the previous row data. **This is necessary to define if row data is not immutible for row changes to correctly propagate, if your row data is immutable DO NOT DEFINE, see #28 for reasons why**.
+**`order`** | Array (Optional) | Expects an array of keys to determine the current order of rows.
+**`sortRowStyle`** | Object (Optional) | Expects a `style` object, which is to be applied on the rows when they're being dragged.
+**`disableSorting`** | Boolean (Optional) | When set to true, all sorting will be disabled, which will effectively make the SortableListView act like a normal ListView.
+**`onMoveStart`** | Function (Optional) | Register a handler to be called when drag start.
+**`onMoveEnd`** | Function (Optional) | Register a handler to be called when move is completed.
+**`onRowActive`** | Function (Optional) | Register a handler to be called when row is activated, return a object contains three properties `rowData`, `touch` and `layout`. `rowData` is the data info of activated row, `layout` is the layout info of the activated row, `touch` is the `nativeEvent` of long press
+**`onMoveCancel`** | Function (Optional) | Register a handler to be called when move is canceled, that is the row is activated on long press and then released without any move.
+**`activeOpacity`** | Number (Optional) | Sets opacity of an active element. Default value: `0.2`.
+**`limitScrolling`** | Boolean (Optional) | When set to true, scrolling will be disabled when a row is active (sorting). Default is `false`.
+**`moveOnPressIn`** | Boolean (Optional) | When set to true, longPress delay is eliminated. Default is `false`.
+**`ListViewComponent`** | _(Function) (Optional) | A custom ListView component to be used instead of React-Native's ListView.
+**`disableAnimatedScrolling`** | Boolean (Optional) | When set to true, scrolling will no longer animate. Default is `false`. **Strongly recommend set it to `true`.**, see #97 for more context.
 
 
-## methods
+## Methods
 
-- **`scrollTo(...args)`** - Scrolls to a given x, y offset, either immediately or with a smooth animation. See ScrollView's scrollTo method.
+Name | Description
+:--- | :---
+**`scrollTo(...args)`** | Scrolls to a given x, y offset, either immediately or with a smooth animation. [See ScrollView's scrollTo method](https://facebook.github.io/react-native/docs/scrollview#scrollto).
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ import React from 'react'
 import {
   View,
   Animated,
-  ListView,
   Dimensions,
   PanResponder,
   LayoutAnimation,
   InteractionManager,
 } from 'react-native'
+import ListView from 'deprecated-react-native-listview'
 
 const HEIGHT = Dimensions.get('window').height
 
@@ -148,7 +148,7 @@ class SortableListView extends React.Component {
     const currentPanValue = { x: 0, y: 0 }
 
     this.state = {
-      ds: new ListView.DataSource({
+      ds: new (props.ListViewComponent || ListView).DataSource({
         rowHasChanged: (r1, r2) => {
           if (props.rowHasChanged) return props.rowHasChanged(r1, r2)
           return false

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "type": "git",
     "url": "git+https://github.com/deanmcpherson/react-native-sortable-listview.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "deprecated-react-native-listview": "^0.0.5"
+  },
   "keywords": [
     "react-component",
     "ios",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sortable-listview",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Drag drop capable wrapper of ListView for React Native",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,11 @@ core-js@^2.2.2, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
+core-js@^2.4.1:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1236,6 +1241,15 @@ core-util-is@~1.0.0:
 crc@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.3.0.tgz#fa622e1bc388bf257309082d6b65200ce67090ba"
+
+create-react-class@*:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 create-react-class@^15.5.2:
   version "15.6.0"
@@ -1340,6 +1354,16 @@ depd@~1.0.1:
 depd@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
+
+deprecated-react-native-listview@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/deprecated-react-native-listview/-/deprecated-react-native-listview-0.0.5.tgz#fc8a6dc45b0a8ba611e6014e13b38d6d763e763f"
+  integrity sha512-Cy7nDdd+KU+nR3tY1BSMuoZpsYC6OVSZyAiUSTDBop2lIgzCseDx7XI57x6h+NXer/8aor2yiQDQfeFcmBMwgQ==
+  dependencies:
+    create-react-class "*"
+    fbjs "*"
+    invariant "*"
+    react-clone-referenced-element "*"
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -1520,6 +1544,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
 fbjs-scripts@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/fbjs-scripts/-/fbjs-scripts-0.7.1.tgz#4f115e218e243e3addbf0eddaac1e3c62f703fac"
@@ -1532,6 +1561,20 @@ fbjs-scripts@^0.7.0:
     object-assign "^4.0.1"
     semver "^5.1.0"
     through2 "^2.0.0"
+
+fbjs@*:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fbjs@0.8.12, fbjs@^0.8.9:
   version "0.8.12"
@@ -1877,6 +1920,13 @@ inquirer@^0.12.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
     through "^2.3.6"
+
+invariant@*:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -3053,6 +3103,11 @@ raw-body@~2.1.2:
     iconv-lite "0.4.13"
     unpipe "1.0.0"
 
+react-clone-referenced-element@*:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz#9cdda7f2aeb54fea791f3ab8c6ab96c7a77d0158"
+  integrity sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg==
+
 react-clone-referenced-element@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz#2bba8c69404c5e4a944398600bcc4c941f860682"
@@ -3759,6 +3814,11 @@ type-is@~1.6.6:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
 ua-parser-js@^0.7.9:
   version "0.7.13"


### PR DESCRIPTION
With React Native 0.60.0, `ListView` has been removed. It's still accessible using `deprecated-react-native-listview`, which is what the original library uses now.