### PR TITLE
Add UNSAFE to componentWill(Mount|ReceiveProps) deprecated methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -465,7 +465,7 @@ class SortableListView extends React.Component {
     })
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setOrder(this.props)
   }
 
@@ -475,7 +475,7 @@ class SortableListView extends React.Component {
     })
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     this.setOrder(props)
   }
 


### PR DESCRIPTION
Updating to React Native 0.60.0 means that these life-cycle methods are causing yellow-box warnings. Instead of changing the underlying methods, we can add `UNSAFE_` for now. 

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html 
